### PR TITLE
Withdraw Requires Deposit Tokens

### DIFF
--- a/packages/contracts/contracts/WithdrawRequestNFT.sol
+++ b/packages/contracts/contracts/WithdrawRequestNFT.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.13;
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "hardhat/console.sol";
 
@@ -42,6 +43,11 @@ contract WithdrawRequestNFT is ERC721URIStorage {
         return newItemId;
     }
 
+    /// @dev transfering locked tokens to the given address
+    function withdrawTo(address _token, uint256 _amount, address _recipient) external onlyExchange {
+        IERC20(_token).transfer(_recipient, _amount);
+    }
+
     function tokenURI(uint256 id) public view override returns (string memory) {
 
             string memory jsonPreImage = string.concat(
@@ -75,6 +81,8 @@ contract WithdrawRequestNFT is ERC721URIStorage {
     function getTokenAddress(uint256 id) public view returns (address) {
         return tokenAddresses[id];
     }
+
+
 
     /****************************************
      *          INTERNAL FUNCTIONS          *

--- a/packages/contracts/contracts/interfaces/IWithdrawRequestNFT.sol
+++ b/packages/contracts/contracts/interfaces/IWithdrawRequestNFT.sol
@@ -10,4 +10,6 @@ interface IWithdrawRequestNFT {
 
     function getTokenAddress(uint256 _id) external view returns (address);
 
+    function withdrawTo(address _token, uint256 _amount, address _recipient) external;
+
 }

--- a/packages/contracts/test/exchange.js
+++ b/packages/contracts/test/exchange.js
@@ -108,6 +108,10 @@ describe("#exchange", () => {
         expect(await rebaseToken.balanceOf(bob.address)).to.equal(toEther(0.55))
         expect(await rebaseToken.balanceOf(charlie.address)).to.equal(toEther(0.55))
 
+        // preparing deposit tokens into the NFT contract
+        await rebaseToken.connect(bob).approve(exchange.target, ethers.MaxUint256)
+        await rebaseToken.connect(charlie).approve(exchange.target, ethers.MaxUint256)
+
         // request withdrawal for both bob and charlie
         await exchange.connect(bob).requestWithdraw(rebaseToken.target, toEther(0.55), mockWETH.target, toEther(0.55))
         await exchange.connect(charlie).requestWithdraw(rebaseToken.target, toEther(0.55), mockWETH.target, toEther(0.55))
@@ -128,9 +132,6 @@ describe("#exchange", () => {
         await mockWETH.mintTo(exchange.target, toEther(2))
 
         // withdrawing
-        await rebaseToken.connect(bob).approve(exchange.target, ethers.MaxUint256)
-        await rebaseToken.connect(charlie).approve(exchange.target, ethers.MaxUint256)
-
         await nft.connect(bob).approve(exchange.target, 1)
         await nft.connect(charlie).approve(exchange.target, 2)
 


### PR DESCRIPTION
This PR updates the withdrawal process to require users to deposit tokens first when making a request.